### PR TITLE
feat(embeddedServiceDeploy): adds embedded service deploy

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -2,6 +2,7 @@
   "orgName": "Google",
   "edition": "Enterprise",
   "features": [
+    "Communities",
     "EnableSetPasswordInApi",
     "LiveMessage",
     "ServiceCloud",
@@ -9,6 +10,12 @@
     "ServiceCloudVoicePartnerTelephony:1"
   ],
   "settings": {
+    "communitiesSettings": {
+      "enableNetworksEnabled": true
+    },
+    "experienceBundleSettings": {
+      "enableExperienceBundleMetadata": true
+    },
     "lightningExperienceSettings": {
       "enableS1DesktopEnabled": true
     },

--- a/force-app/main/default/classes/EmbeddedServiceSetup.cls
+++ b/force-app/main/default/classes/EmbeddedServiceSetup.cls
@@ -1,0 +1,56 @@
+/*
+TODO:
+- Find out how to get siteId
+*/
+public class EmbeddedServiceSetup {
+
+    @AuraEnabled
+    public static void createDeployment(String siteDeveloperName) {
+        Map<String, Object> channelConfig = new Map<String, Object>{
+            'messagingChannel' => 'Messaging_Channel',
+            'isEnabled' => true,
+            // API 64.0 often requires these defaults to be explicit
+            'shouldShowDeliveryReceipts' => false,
+            'shouldShowReadReceipts' => false,
+            'shouldShowTypingIndicators' => false,
+            'shouldStartNewLineOnEnter' => false,
+            'shouldShowEmojiSelection' => false
+        };
+
+        // 2. Define the Metadata Structure
+        Map<String, Object> metadataContent = new Map<String, Object>{
+            'masterLabel' => 'Messaging Embedded Service Deployment',
+            'deploymentFeature' => 'EmbeddedMessaging',
+            'site' => siteDeveloperName + '1',
+            'deploymentType' => 'Web',
+            'areGuestUsersAllowed' => false,
+            'isEnabled' => true,
+            'embeddedServiceMessagingChannel' => channelConfig // NESTED HERE
+        };
+
+        // 3. Wrap for Tooling API
+        Map<String, Object> payload = new Map<String, Object>{
+            'FullName' => 'Messaging_Embedded_Service_Deployment',
+            'Metadata' => metadataContent
+        };
+
+        // 2. Construct the HTTP Request
+        HttpRequest req = new HttpRequest();
+        req.setEndpoint(Url.getOrgDomainUrl().toExternalForm() + '/services/data/v60.0/tooling/sobjects/EmbeddedServiceConfig');
+        req.setMethod('POST');
+        req.setHeader('Authorization', 'OAuth ' + UserInfo.getSessionId()); // Uses current session
+        req.setHeader('Content-Type', 'application/json');
+        req.setBody(JSON.serialize(payload));
+
+        // 3. Send Request
+        Http http = new Http();
+        HttpResponse res = http.send(req);
+
+        if (res.getStatusCode() == 201) {
+            System.debug('Success! Deployment Created. ID: ' + res.getBody());
+        } else {
+            System.debug('Error: ' + res.getBody());
+            throw new AuraHandledException('Error: ' + res.getBody());
+        }
+    }
+}

--- a/force-app/main/default/classes/EmbeddedServiceSetup.cls-meta.xml
+++ b/force-app/main/default/classes/EmbeddedServiceSetup.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/MessageChannelSetup.cls
+++ b/force-app/main/default/classes/MessageChannelSetup.cls
@@ -1,0 +1,79 @@
+public class MessageChannelSetup {
+
+    @AuraEnabled
+    public static void install() {
+        try {
+            // 1. Handle the Queue (Steps 4)
+            Group queue = ensureQueueExists('Agent Assist', 'Agent_Assist');
+            
+            // 2. Ensure Queue supports MessagingSession objects
+            ensureQueueSupportsObject(queue.Id, 'MessagingSession');
+
+            // 3. Create the Messaging Channel (Steps 1-3, 5, 6)
+            createEnhancedChannel('Messaging Channel', queue.Id);
+            
+        } catch (Exception e) {
+            System.debug('Installation Error: ' + e.getMessage());
+            throw e;
+        }
+    }
+
+    private static Group ensureQueueExists(String label, String developerName) {
+        List<Group> groups = [SELECT Id FROM Group WHERE DeveloperName = :developerName AND Type = 'Queue' LIMIT 1];
+        
+        if (!groups.isEmpty()) {
+            return groups[0];
+        }
+
+        Group newQueue = new Group(
+            Name = label,
+            DeveloperName = developerName,
+            Type = 'Queue'
+        );
+        insert newQueue;
+        return newQueue;
+    }
+
+    private static void ensureQueueSupportsObject(Id queueId, String objectType) {
+        List<QueueSobject> qsos = [SELECT Id FROM QueueSobject WHERE QueueId = :queueId AND SobjectType = :objectType LIMIT 1];
+        
+        if (qsos.isEmpty()) {
+            QueueSobject qso = new QueueSobject(
+                QueueId = queueId,
+                SobjectType = objectType
+            );
+            insert qso;
+        }
+    }
+
+    private static void createEnhancedChannel(String channelName, Id queueId) {
+        // Check if channel already exists to prevent duplicates
+        List<MessagingChannel> existingChannels = [SELECT Id FROM MessagingChannel WHERE MasterLabel = :channelName LIMIT 1];
+        if (!existingChannels.isEmpty()) {
+            return; 
+        }
+
+        MessagingChannel channel = new MessagingChannel();
+        channel.MasterLabel = channelName;
+        channel.DeveloperName = channelName.replaceAll('\\s+', '_'); // e.g., Messaging_Channel
+        
+        // "Enhanced Chat" corresponds to the 'EmbeddedMessaging' type
+        channel.MessageType = 'EmbeddedMessaging';
+        
+        // For EmbeddedMessaging, we generate a unique Platform Key (UUID)
+        // This mimics the backend provisioning that happens in the UI
+        channel.MessagingPlatformKey = UUID.randomUUID().toString();
+        
+        // Routing Configuration (Step 4)
+        channel.RoutingType = 'OmniQueue';
+        channel.TargetQueueId = queueId; // Links to "Messaging Queue"
+        
+        // Activation (Step 6)
+        channel.IsActive = true; 
+
+        // Additional required fields for context
+        channel.Description = 'Created via Package Installer';
+
+        insert channel;
+    }
+}

--- a/force-app/main/default/classes/MessageChannelSetup.cls-meta.xml
+++ b/force-app/main/default/classes/MessageChannelSetup.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/SiteDiscovery.cls
+++ b/force-app/main/default/classes/SiteDiscovery.cls
@@ -1,0 +1,26 @@
+public with sharing class SiteDiscovery {
+    @AuraEnabled(cacheable=true)
+    public static Map<String, String> getSiteInfo(String siteName) {
+        List<Network> networks = [
+            SELECT Id, Name 
+            FROM Network 
+            WHERE Name = :siteName 
+            LIMIT 1
+        ];
+
+        if (networks.isEmpty()) return null;
+
+        List<Site> sites = [
+            SELECT Id, SiteType 
+            FROM Site 
+            WHERE Name = :networks[0].Name 
+            LIMIT 1
+        ];
+
+        return new Map<String, String>{
+            'siteDeveloperName' => networks[0].Name,
+            'siteId' => (sites.isEmpty() ? null : sites[0].Id),
+            'siteType' => (sites.isEmpty() ? null : sites[0].SiteType)
+        };
+    }
+}

--- a/force-app/main/default/classes/SiteDiscovery.cls-meta.xml
+++ b/force-app/main/default/classes/SiteDiscovery.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/lwc/setupAssistant/setupAssistant.html
+++ b/force-app/main/default/lwc/setupAssistant/setupAssistant.html
@@ -31,11 +31,13 @@
                 <li><strong>User Access:</strong> Automatically assigns the permission set to <strong>you</strong>.</li>
             </ul>
 
+            <lightning-input label="Site Name" value={siteName} onchange={handleNameChange} required placeholder="e.g. GoogleApi"></lightning-input>
+
             <lightning-button 
                 variant="brand" 
                 label="Deploy Metadata Resources" 
                 onclick={handleDeploy}
-                disabled={isLoading}>
+                disabled={isDeployButtonDisabled}>
             </lightning-button>
 
             <template lwc:if={isLoading}>

--- a/force-app/main/default/lwc/setupAssistant/setupAssistant.js
+++ b/force-app/main/default/lwc/setupAssistant/setupAssistant.js
@@ -1,25 +1,50 @@
 import { LightningElement, track } from 'lwc';
 import deployMetadata from '@salesforce/apex/SetupAssistantController.deployMetadata';
+import setupEmbeddedServiceDeploy from '@salesforce/apex/EmbeddedServiceSetup.createDeployment';
+import setupMessageChannel from '@salesforce/apex/MessageChannelSetup.install';
+import getSiteInfo from '@salesforce/apex/SiteDiscovery.getSiteInfo';
 
 export default class SetupAssistant extends LightningElement {
     @track isLoading = false;
     @track isSuccess = false;
     @track error;
+    siteName = '';
 
-    handleDeploy() {
+    handleNameChange(event) {
+        this.siteName = event.target.value;
+    }
+
+    get isDeployButtonDisabled() {
+        return this.isLoading || !this.siteName;
+    }
+    
+    async handleDeploy() {
         this.isLoading = true;
         this.error = null;
         this.isSuccess = false;
 
-        deployMetadata()
-            .then(result => {
-                this.isSuccess = true;
-            })
-            .catch(error => {
+        try {
+            
+            await deployMetadata()
+            
+            /**
+             * @type {{
+             *  siteDeveloperName: string;
+             *  siteId: string
+             * }}
+             */
+            const siteInfo = await getSiteInfo({ siteName: this.siteName })
+    
+            await setupMessageChannel()
+            
+            await setupEmbeddedServiceDeploy({ siteDeveloperName: siteInfo.siteDeveloperName })
+
+            this.isSuccess = true;
+
+        } catch(error ){
                 this.error = error.body ? error.body.message : error.message;
-            })
-            .finally(() => {
+        } finally {
                 this.isLoading = false;
-            });
+        }
     }
 }

--- a/force-app/main/default/profiles/Admin.profile-meta.xml
+++ b/force-app/main/default/profiles/Admin.profile-meta.xml
@@ -181,10 +181,6 @@
     </userPermissions>
     <userPermissions>
         <enabled>true</enabled>
-        <name>CreateWorkBadgeDefinition</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
         <name>CreateWorkspaces</name>
     </userPermissions>
     <userPermissions>
@@ -306,10 +302,6 @@
     <userPermissions>
         <enabled>true</enabled>
         <name>ExternalClientAppViewer</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>FieldServiceAccess</name>
     </userPermissions>
     <userPermissions>
         <enabled>true</enabled>
@@ -645,10 +637,6 @@
     </userPermissions>
     <userPermissions>
         <enabled>true</enabled>
-        <name>SendExternalEmailAvailable</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
         <name>SendSitRequests</name>
     </userPermissions>
     <userPermissions>
@@ -802,10 +790,6 @@
     <userPermissions>
         <enabled>true</enabled>
         <name>ViewRoles</name>
-    </userPermissions>
-    <userPermissions>
-        <enabled>true</enabled>
-        <name>ViewSALifecycle</name>
     </userPermissions>
     <userPermissions>
         <enabled>true</enabled>


### PR DESCRIPTION
# Description

Programmatically created  EmbeddedServiceConfig and MessagingChannel. Please read #6. This shouldn't be merged until we figure out whether this is actually doing what we need, and whether it reduces any overheard.

## LWC View

Contains inputs to create [EmbeddedServiceConfig](https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/tooling_api_objects_embeddedserviceconfig.htm).

### Inputs

*siteName* - Name of the user's Digital Experience site.

## Classes

### SiteDiscovery
Retrieves the site developer name from the `siteName`. We might be able to workaround this request if it's guaranteed that the site developer name will always be the `siteName`, where spaces are replaced with underscores. In which case, we can just replace spaces with underscores.

### EmbeddedServiceSetup

Creates the `EmbeddedServiceConfig`, using `siteDeveloperName` as the `site` property.

You'll notice a `1` is concatenated to `siteDeveloperName` -- this is because there are two `Site`s created with different `siteType`s. The regular site associated with `siteDeveloperName` is of `siteType` `ChatterNetwork`, and the is `ChatterNetworkPicasso` (`siteDeveloperName + '1'`).

`ChatterNetworkPicasso` is required for `EmbeddedServiceConfig` to be created.

### MessageChannelSetup

Creates a `MessagingChannel` for `EmbeddedServiceConfig` to reference.